### PR TITLE
feat(brand-typography): add Code display font wiring with IBM Plex Mo…

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EngageNatural - Admin Dashboard</title>
   </head>

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  PNPM_FLAGS = "--no-frozen-lockfile"
   # Default fallback if context not matched
   VITE_USE_EMULATOR = "false"
   VITE_SHOW_DEBUG = "false"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "normalize:firebase": "node scripts/normalize-firebase-imports.mjs --write"
   },
   "dependencies": {
-    "@fontsource/inter": "^5.2.6",
-    "@fontsource/playfair-display": "^5.2.6",
+    "@fontsource-variable/geist": "^5.1.0",
+    "@fontsource/libre-baskerville": "^5.2.6",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-accordion": "^1.2.10",
     "@radix-ui/react-alert-dialog": "^1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/geist':
+        specifier: ^5.1.0
+        version: 5.2.8
       '@fontsource/ibm-plex-mono':
         specifier: ^5.2.7
         version: 5.2.7
-      '@fontsource/inter':
+      '@fontsource/libre-baskerville':
         specifier: ^5.2.6
-        version: 5.2.6
-      '@fontsource/playfair-display':
-        specifier: ^5.2.6
-        version: 5.2.6
+        version: 5.2.8
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.1.1(react-hook-form@7.60.0(react@19.1.0))
@@ -746,14 +746,14 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@fontsource-variable/geist@5.2.8':
+    resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
+
   '@fontsource/ibm-plex-mono@5.2.7':
     resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
 
-  '@fontsource/inter@5.2.6':
-    resolution: {integrity: sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==}
-
-  '@fontsource/playfair-display@5.2.6':
-    resolution: {integrity: sha512-hWfFm2j+Dlg+UwabNJu5vi45otmLSG64hUzNFJ8pIDBgqWBviEPpVaDIZWHm2RYyIxhg9YXTPsZWdpvsu7fkqQ==}
+  '@fontsource/libre-baskerville@5.2.8':
+    resolution: {integrity: sha512-jE+bedLb020OK2KDBZWJ2Wos4maagvnMcTwsxRjpMNxANW4GiD8lZF8Yezc8e+GDGG9UfJzJPbWfYun55JIWoA==}
 
   '@grpc/grpc-js@1.9.15':
     resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
@@ -3457,11 +3457,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@fontsource-variable/geist@5.2.8': {}
+
   '@fontsource/ibm-plex-mono@5.2.7': {}
 
-  '@fontsource/inter@5.2.6': {}
-
-  '@fontsource/playfair-display@5.2.6': {}
+  '@fontsource/libre-baskerville@5.2.8': {}
 
   '@grpc/grpc-js@1.9.15':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@fontsource/inter':
         specifier: ^5.2.6
         version: 5.2.6
@@ -742,6 +745,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
 
   '@fontsource/inter@5.2.6':
     resolution: {integrity: sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==}
@@ -3450,6 +3456,8 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fontsource/ibm-plex-mono@5.2.7': {}
 
   '@fontsource/inter@5.2.6': {}
 

--- a/src/App.css
+++ b/src/App.css
@@ -2,15 +2,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@import "@fontsource/playfair-display/400.css";
-@import "@fontsource/playfair-display/600.css";
-@import "@fontsource/playfair-display/700.css";
-@import "@fontsource/playfair-display/800.css";
-@import "@fontsource/playfair-display/900.css"; /* Added 900 weight for extra thick headlines */
-@import "@fontsource/inter/400.css";
-@import "@fontsource/inter/500.css";
-@import "@fontsource/inter/600.css";
-@import "@fontsource/inter/700.css"; /* Added for subheadings */
+/* Fonts are loaded via BrandFonts() using @fontsource-variable/geist and @fontsource/libre-baskerville */
 
 @custom-variant dark (&:is(.dark *));
 
@@ -132,89 +124,68 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   }
   
   /* FIXED Typography - Headlines thicker, subheadings Inter */
 .font-heading {
-    font-family: 'Playfair Display', serif;
-    font-weight: 900 !important; /* Increased from 700 to 900 for thicker headlines */
-    letter-spacing: -0.02em !important;
+    font-family: 'Libre Baskerville', Georgia, serif;
+    font-weight: 800 !important;
+    letter-spacing: -0.01em !important;
     line-height: 1.2 !important;
-  }
+}
   
-  .font-body {
-    font-family: 'Inter', sans-serif;
-  }
+  .font-body { font-family: 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
   
   /* Main headlines - Extra thick and readable */
 h1, .text-4xl, .text-3xl {
-    font-family: 'Playfair Display', serif;
-    font-weight: 900 !important; /* Extra thick for main headlines */
-    letter-spacing: -0.015em !important;
-    line-height: 1.1 !important;
-  }
+    font-family: 'Libre Baskerville', Georgia, serif;
+    font-weight: 800 !important;
+    letter-spacing: -0.01em !important;
+    line-height: 1.15 !important;
+}
   
   /* Section headings - Still Playfair but slightly less thick */
 h2, .text-2xl, .text-xl {
-    font-family: 'Playfair Display', serif;
-    font-weight: 800 !important; /* Thick but not as thick as h1 */
-    letter-spacing: -0.02em !important;
+    font-family: 'Libre Baskerville', Georgia, serif;
+    font-weight: 700 !important;
+    letter-spacing: -0.01em !important;
     line-height: 1.2 !important;
-  }
+}
   
   /* FIXED: Subsection titles - Back to Inter font */
 h3, h4, h5, h6, .text-lg {
-    font-family: 'Inter', sans-serif !important; /* Changed back to Inter */
-    font-weight: 700 !important; /* Bold Inter for subheadings */
-    letter-spacing: -0.005em !important; /* Slight tightening for Inter */
-    line-height: 1.3 !important;
-  }
+    font-family: 'Libre Baskerville', Georgia, serif !important;
+    font-weight: 600 !important;
+    letter-spacing: -0.005em !important;
+    line-height: 1.25 !important;
+}
   
   /* Small text and labels - Inter */
-  .text-sm, .text-xs, label, .label {
-    font-family: 'Inter', sans-serif !important;
-    font-weight: 500 !important;
-  }
+  .text-sm, .text-xs, label, .label { font-family: 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif !important; font-weight: 500 !important; }
   
   /* Button text - Inter */
-  button, .btn {
-    font-family: 'Inter', sans-serif !important;
-    font-weight: 600 !important;
-  }
+  button, .btn { font-family: 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif !important; font-weight: 600 !important; }
   
   /* Override any colored headings to maintain readability */
 /* Allow utility classes (e.g. text-brand-primary) to control color on headings */
   
   /* Brand colors - only for non-heading elements */
-  .text-brand-primary:not(.font-heading):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) {
-    color: #9CAF88; /* sage-green */
-  }
+  .text-brand-primary:not(.font-heading):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) { color: #0E0E0E; }
   
-  .bg-brand-primary {
-    background-color: #9CAF88; /* sage-green */
-  }
+  .bg-brand-primary { background-color: #F2D4CA; }
   
-  .text-brand-secondary:not(.font-heading):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) {
-    color: #4A5D3A; /* deep-moss */
-  }
+  .text-brand-secondary:not(.font-heading):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) { color: #5C5754; }
   
-  .bg-brand-secondary {
-    background-color: #4A5D3A; /* deep-moss */
-  }
+  .bg-brand-secondary { background-color: #F6E3DC; }
   
-  .border-brand-primary {
-    border-color: #9CAF88; /* sage-green */
-  }
+  .border-brand-primary { border-color: #E8C9C2; }
   
   /* Rich Text Editor Styles */
-  .rich-text-preview {
-    overflow-wrap: break-word;
-    font-family: 'Inter', sans-serif;
-  }
+  .rich-text-preview { overflow-wrap: break-word; font-family: 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
   
   .rich-text-preview h1 {
-    font-family: 'Playfair Display', serif;
+    font-family: 'Libre Baskerville', Georgia, serif;
     font-size: 1.75rem;
     font-weight: 800 !important;
     margin-top: 1rem;
@@ -224,7 +195,7 @@ h3, h4, h5, h6, .text-lg {
   }
   
   .rich-text-preview h2 {
-    font-family: 'Playfair Display', serif;
+    font-family: 'Libre Baskerville', Georgia, serif;
     font-size: 1.5rem;
     font-weight: 700 !important;
     margin-top: 1rem;
@@ -234,7 +205,7 @@ h3, h4, h5, h6, .text-lg {
   }
   
   .rich-text-preview h3 {
-    font-family: 'Inter', sans-serif;
+    font-family: 'Libre Baskerville', Georgia, serif;
     font-size: 1.25rem;
     font-weight: 600 !important;
     margin-top: 1rem;
@@ -279,9 +250,7 @@ h3, h4, h5, h6, .text-lg {
   }
   
   /* Quill Editor Styles */
-  .quill {
-    font-family: 'Inter', sans-serif;
-  }
+  .quill { font-family: 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
   
   .quill .ql-toolbar {
     border-top-left-radius: 0.375rem;
@@ -297,10 +266,7 @@ h3, h4, h5, h6, .text-lg {
     min-height: 150px;
   }
   
-  .quill .ql-editor {
-    min-height: 150px;
-    font-family: 'Inter', sans-serif;
-  }
+  .quill .ql-editor { min-height: 150px; font-family: 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
   
   .quill .ql-editor.ql-blank::before {
     font-style: normal;
@@ -308,11 +274,7 @@ h3, h4, h5, h6, .text-lg {
   }
   
   .quill .ql-editor h1, 
-  .quill .ql-editor h2 {
-    font-family: 'Playfair Display', serif;
-  }
+  .quill .ql-editor h2 { font-family: 'Libre Baskerville', Georgia, serif; }
   
-  .quill .ql-editor h3 {
-    font-family: 'Inter', sans-serif;
-  }
+  .quill .ql-editor h3 { font-family: 'Libre Baskerville', Georgia, serif; }
 }

--- a/src/brand/palette.ts
+++ b/src/brand/palette.ts
@@ -1,61 +1,21 @@
-/**
- * Shared EngageNatural brand palette used across UI components.
- * Duplicates the colour tokens defined in Tailwind/theme CSS so
- * TypeScript imports like "../../brand/palette" resolve correctly.
- */
+// Petal-pink palette sampled from screenshot
+export const BG_PAGE_LIGHT = "#FFFFFF";   // base page
+export const BG_TINT       = "#F6E3DC";   // petal wash for sections/cards
+export const BG_ELEVATED   = "#FFFDFB";   // near-white for panels (optional)
 
-export const brandPalette = {
-	neutrals: {
-		black: '#000000',
-		white: '#FFFFFF',
-	},
-	primary: {
-		base: '#9CAF88',
-		foreground: '#000000',
-	},
-	secondary: {
-		base: '#4A5D3A',
-		foreground: '#FFFFFF',
-	},
-	accent: {
-		base: '#B8C7A6',
-		foreground: '#4A5D3A',
-	},
-	muted: {
-		base: '#F5F1EB',
-		foreground: '#6B6B6B',
-	},
-} as const;
+export const TEXT_PRIMARY  = "#0E0E0E";
+export const TEXT_INVERSE  = "#FFFFFF";
+export const MUTED         = "#5C5754";
 
-export type BrandPalette = typeof brandPalette;
+export const ACCENT_PINK   = "#F2D4CA";   // primary accent (petal)
+export const ACCENT_PINK_LIGHT = "#F3DAD1";
+export const ACCENT_PINK_DARK  = "#CDB4AB";
 
-export type BrandPaletteKey =
-	| 'neutrals.black'
-	| 'neutrals.white'
-	| 'primary.base'
-	| 'primary.foreground'
-	| 'secondary.base'
-	| 'secondary.foreground'
-	| 'accent.base'
-	| 'accent.foreground'
-	| 'muted.base'
-	| 'muted.foreground';
+export const BORDER        = "#E8C9C2";   // soft pink border
 
-const paletteLookup: Record<BrandPaletteKey, string> = {
-	'neutrals.black': brandPalette.neutrals.black,
-	'neutrals.white': brandPalette.neutrals.white,
-	'primary.base': brandPalette.primary.base,
-	'primary.foreground': brandPalette.primary.foreground,
-	'secondary.base': brandPalette.secondary.base,
-	'secondary.foreground': brandPalette.secondary.foreground,
-	'accent.base': brandPalette.accent.base,
-	'accent.foreground': brandPalette.accent.foreground,
-	'muted.base': brandPalette.muted.base,
-	'muted.foreground': brandPalette.muted.foreground,
+// Buttons (keep high contrast; add a pink variant for emphasis)
+export const BUTTON = {
+  primary:   { bg: "#0E0E0E", fg: "#FFFFFF", hover: "#1A1A1A", border: "#0E0E0E" },
+  secondary: { bg: "transparent", fg: "#0E0E0E", border: "#0E0E0E", hover: "#0E0E0E", hoverFg: "#FFFFFF" },
+  pink:      { bg: ACCENT_PINK, fg: "#0E0E0E", hover: ACCENT_PINK_DARK, border: ACCENT_PINK }
 };
-
-export function getBrandColor(token: BrandPaletteKey): string {
-	return paletteLookup[token];
-}
-
-export default brandPalette;

--- a/src/brand/typography.ts
+++ b/src/brand/typography.ts
@@ -1,0 +1,46 @@
+/*
+  Brand typography integration
+  - Provides font stacks and a BrandFonts component that wires the custom
+    display font "Code" with safe fallbacks.
+*/
+
+import React from 'react'
+
+// Fallback mono font for display usage
+// Note: This import is safe even if the actual "Code" font files are missing.
+import '@fontsource/ibm-plex-mono/400.css'
+
+export const BODY_STACK = 'Geist, "Geist Fallback", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif'
+export const HEADING_STACK = '"Libre Baskerville", Georgia, serif'
+export const DISPLAY_STACK = '"Code", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
+
+export const classes = {
+  body: 'font-sans',
+  heading: 'font-serif',
+  display: 'font-display',
+}
+
+export function BrandFonts(): JSX.Element {
+  // Inject @font-face for "Code"; files may not exist yet. font-display: swap.
+  const css = `
+  @font-face {
+    font-family: 'Code';
+    src: url('/fonts/code.woff2') format('woff2'),
+         url('/fonts/code.woff') format('woff');
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    /* Basic Latin range */
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC,
+                   U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
+                   U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+                   U+FEFF, U+FFFD;
+  }
+  `
+  return React.createElement(
+    'style',
+    { dangerouslySetInnerHTML: { __html: css } } as any,
+  )
+}
+
+export default BrandFonts

--- a/src/brand/typography.ts
+++ b/src/brand/typography.ts
@@ -3,11 +3,21 @@ export const BODY_STACK =
   'Geist, "Geist Fallback", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
 export const HEADING_STACK = '"Libre Baskerville", Georgia, serif';
 
+import { useEffect } from 'react'
+
 export function BrandFonts() {
-  // Factory: ensure these packages are installed:
-  // npm i @fontsource-variable/geist @fontsource/libre-baskerville
-  import('@fontsource-variable/geist');
-  import('@fontsource/libre-baskerville');
+  // Load fonts after first render to keep component pure and avoid StrictMode double-run issues
+  useEffect(() => {
+    Promise.all([
+      import('@fontsource-variable/geist'),
+      import('@fontsource/libre-baskerville'),
+      import('@fontsource/ibm-plex-mono/400.css'),
+    ]).catch((err) => {
+      // Non-blocking: log for diagnostics but do not surface to users
+      console.error('BrandFonts: failed to load one or more fonts', err)
+    })
+  }, [])
+
   return null;
 }
 

--- a/src/brand/typography.ts
+++ b/src/brand/typography.ts
@@ -1,47 +1,17 @@
-/*
-  Brand typography integration
-  - Provides font stacks and a BrandFonts component that wires the custom
-    display font "Code" with safe fallbacks.
-*/
+// Fonts: Geist (UI) + Libre Baskerville (headings)
+export const BODY_STACK =
+  'Geist, "Geist Fallback", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+export const HEADING_STACK = '"Libre Baskerville", Georgia, serif';
 
-import React from 'react'
-
-// Fallback mono font for display usage
-// Note: This import is safe even if the actual "Code" font files are missing.
-// NOTE: Fallback font CSS is imported globally from src/index.css to avoid
-// bundler resolution issues in some CI environments.
-
-export const BODY_STACK = 'Geist, "Geist Fallback", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif'
-export const HEADING_STACK = '"Libre Baskerville", Georgia, serif'
-export const DISPLAY_STACK = '"Code", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
+export function BrandFonts() {
+  // Factory: ensure these packages are installed:
+  // npm i @fontsource-variable/geist @fontsource/libre-baskerville
+  import('@fontsource-variable/geist');
+  import('@fontsource/libre-baskerville');
+  return null;
+}
 
 export const classes = {
   body: 'font-sans',
   heading: 'font-serif',
-  display: 'font-display',
-}
-
-export function BrandFonts(): JSX.Element {
-  // Inject @font-face for "Code"; files may not exist yet. font-display: swap.
-  const css = `
-  @font-face {
-    font-family: 'Code';
-    src: url('/fonts/code.woff2') format('woff2'),
-         url('/fonts/code.woff') format('woff');
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    /* Basic Latin range */
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC,
-                   U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
-                   U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-                   U+FEFF, U+FFFD;
-  }
-  `
-  return React.createElement(
-    'style',
-    { dangerouslySetInnerHTML: { __html: css } } as any,
-  )
-}
-
-export default BrandFonts
+};

--- a/src/brand/typography.ts
+++ b/src/brand/typography.ts
@@ -8,7 +8,8 @@ import React from 'react'
 
 // Fallback mono font for display usage
 // Note: This import is safe even if the actual "Code" font files are missing.
-import '@fontsource/ibm-plex-mono/400.css'
+// NOTE: Fallback font CSS is imported globally from src/index.css to avoid
+// bundler resolution issues in some CI environments.
 
 export const BODY_STACK = 'Geist, "Geist Fallback", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif'
 export const HEADING_STACK = '"Libre Baskerville", Georgia, serif'

--- a/src/components/PublicWebsite.jsx
+++ b/src/components/PublicWebsite.jsx
@@ -5,6 +5,8 @@ import { Input } from './ui/input'
 import { Textarea } from './ui/textarea'
 import { CheckCircle, ArrowRight, Users, MessageSquare, Trophy, BookOpen, Brain, BarChart3, Star, Award, Clock, CheckCircle2, LogIn, Calendar, Building2, UserCheck, Zap, Shield, Heart, Gamepad2 } from 'lucide-react'
 import LoginWidget from './LoginWidget'
+import BrandTitle from '@/components/typography/BrandTitle'
+import Kicker from '@/components/typography/Kicker'
 
 // Import assets
 import salesImpactGraph from '../assets/sales_impact_graph.png'
@@ -88,12 +90,10 @@ export default function PublicWebsite() {
       <section className="pt-20 pb-16 bg-gradient-to-br from-green-50 to-blue-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <h1 className="text-5xl md:text-6xl font-bold text-brand-primary mb-6 font-heading">
+            <BrandTitle as="h1" className="text-5xl md:text-6xl font-bold text-brand-primary mb-6">
               Engage<span className="text-brand-secondary">Natural</span>
-            </h1>
-            <p className="text-xl text-gray-600 mb-4 max-w-3xl mx-auto font-body">
-              Learn. Connect. Grow. Naturally
-            </p>
+            </BrandTitle>
+            <Kicker as="div" className="mb-2">Learn. Connect. Grow. Naturally</Kicker>
             <p className="text-lg text-brand-secondary font-semibold mb-8 max-w-3xl mx-auto font-body">
               More Than Training… It's a Movement
             </p>

--- a/src/components/typography/BrandTitle.tsx
+++ b/src/components/typography/BrandTitle.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+type BrandTitleProps = {
+  children: React.ReactNode
+  as?: 'h1' | 'h2' | 'h3'
+  compact?: boolean
+  className?: string
+}
+
+export default function BrandTitle({ children, as = 'h1', compact = false, className = '' }: BrandTitleProps) {
+  const Tag = as
+  const classes = ['font-display', 'brand-title']
+  if (compact) classes.push('headline-compact')
+  if (className) classes.push(className)
+
+  return <Tag className={classes.join(' ')}>{children}</Tag>
+}
+
+export { BrandTitle }

--- a/src/components/typography/Kicker.tsx
+++ b/src/components/typography/Kicker.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+type KickerProps = {
+  children: React.ReactNode
+  as?: 'div' | 'span'
+  muted?: boolean
+  className?: string
+}
+
+export default function Kicker({ children, as = 'div', muted = false, className = '' }: KickerProps) {
+  const Tag = as
+  const classes = ['font-display', 'kicker']
+  if (className) classes.push(className)
+
+  const style = muted ? { color: 'var(--muted)' } : undefined
+
+  return <Tag className={classes.join(' ')} style={style}>{children}</Tag>
+}
+
+export { Kicker }

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
 
 /* Import brand colors (must come after Tailwind base to override defaults) */
 @import "./theme/brand-colors.css";
+@import "./styles/globals.css";
 
 /* Utility classes */
 .visually-hidden {

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 /* Import brand colors (must come after Tailwind base to override defaults) */
 @import "./theme/brand-colors.css";
 @import "./styles/globals.css";
+@import "@fontsource/ibm-plex-mono/400.css";
 
 /* Utility classes */
 .visually-hidden {

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,8 @@
 /* Import brand colors (must come after Tailwind base to override defaults) */
 @import "./theme/brand-colors.css";
 @import "./styles/globals.css";
-@import "@fontsource/ibm-plex-mono/400.css";
+/* Fallback font via CDN (avoids CI module resolution issues) */
+@import "./styles/ibm-plex-mono.css";
 
 /* Utility classes */
 .visually-hidden {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,11 @@ import './index.css'
 import './App.css'
 import App from "./App.jsx";  // <-- Change back to regular App.jsx
 import '@/lib/firebase' // Import Firebase configuration
+import { BrandFonts } from '@/brand/typography'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
+    <BrandFonts />
     <App />
   </StrictMode>,
 )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -21,5 +21,6 @@
 
 /* Enforce a minimum size for display titles (18px min) */
 .brand-title {
-  font-size: clamp(1.125rem, 1rem + 1.2vw, 3rem);
+  /* Min ~30px, fluid, Max ~60px to preserve display scale */
+  font-size: clamp(1.875rem, 1rem + 2.5vw, 3.75rem);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,25 @@
+/* Global brand typography helpers */
+
+/* Display stack utility. Uses CSS var for runtime overrides if needed. */
+.font-display {
+  font-family: var(--font-display, "Code"), "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* Kicker: small uppercase preheader */
+.kicker {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  font-size: .75rem; /* 12px */
+  opacity: .9;
+}
+
+/* Compact headline rhythm */
+.headline-compact {
+  line-height: 1.18;
+  letter-spacing: .2px;
+}
+
+/* Enforce a minimum size for display titles (18px min) */
+.brand-title {
+  font-size: clamp(1.125rem, 1rem + 1.2vw, 3rem);
+}

--- a/src/styles/ibm-plex-mono.css
+++ b/src/styles/ibm-plex-mono.css
@@ -1,0 +1,9 @@
+/* Minimal fallback: IBM Plex Mono 400 via CDN to avoid CI module resolution issues */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://cdn.jsdelivr.net/npm/@fontsource/ibm-plex-mono@5.2.7/files/ibm-plex-mono-latin-400-normal.woff2') format('woff2'),
+       url('https://cdn.jsdelivr.net/npm/@fontsource/ibm-plex-mono@5.2.7/files/ibm-plex-mono-latin-400-normal.woff') format('woff');
+}

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -6,6 +6,18 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        // Override base families with brand stacks (keep existing keys)
+        sans: [
+          'Geist', 'Geist Fallback', 'ui-sans-serif', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'sans-serif'
+        ],
+        serif: [
+          'Libre Baskerville', 'Georgia', 'serif'
+        ],
+        display: [
+          'Code', 'IBM Plex Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'Consolas', 'monospace'
+        ],
+      },
       colors: {
         // EngageNatural Brand Colors
         "black": "#000000",
@@ -42,12 +54,6 @@ export default {
         "brand-primary": "#9CAF88", // sage-green
         "brand-secondary": "#4A5D3A", // deep-moss
         "brand-accent": "#F5F1EB", // oat-beige
-      },
-      fontFamily: {
-        sans: ['Inter', 'sans-serif'],
-        serif: ['Playfair Display', 'serif'],
-        heading: ['Playfair Display', 'serif'],
-        body: ['Inter', 'sans-serif'],
       },
       borderRadius: {
         DEFAULT: '0.625rem',

--- a/src/theme/brand-colors.css
+++ b/src/theme/brand-colors.css
@@ -5,44 +5,43 @@
  */
 
 :root {
-  /* Brand Color Palette */
-  --color-black: #000000;
+  /* Petal-pink Brand Palette */
+  --color-black: #0E0E0E;
   --color-white: #FFFFFF;
-  --color-sage-green: #9CAF88;
-  --color-oat-beige: #F5F1EB;
-  --color-deep-moss: #4A5D3A;
-  --color-sage-light: #B8C7A6;
-  --color-sage-dark: #7A8E6B;
-  --color-moss-light: #5C7048;
-  --color-oat-dark: #E8E1D5;
-  --color-warm-gray: #6B6B6B;
-  --color-cool-gray: #F8F9FA;
-  
+  --color-petal-pink: #F2D4CA;
+  --color-petal-pink-light: #F3DAD1;
+  --color-petal-pink-dark: #CDB4AB;
+  --color-petal-tint: #F6E3DC;
+  --color-petal-elevated: #FFFDFB;
+  --color-muted-text: #5C5754;
+  --color-soft-border: #E8C9C2;
+
   /* Override functional color variables with brand colors */
-  --primary: var(--color-sage-green) !important;
+  --primary: var(--color-petal-pink) !important;
   --primary-foreground: var(--color-black) !important;
-  --secondary: var(--color-deep-moss) !important;
-  --secondary-foreground: var(--color-white) !important;
-  --muted: var(--color-oat-beige) !important;
-  --muted-foreground: var(--color-warm-gray) !important;
-  --accent: var(--color-sage-light) !important;
-  --accent-foreground: var(--color-deep-moss) !important;
-  
-  /* Override any existing brand color variables */
-  --color-brand-primary: var(--color-sage-green) !important;
-  --color-brand-secondary: var(--color-deep-moss) !important;
-  --color-brand-accent: var(--color-oat-beige) !important;
-  
+  --secondary: var(--color-petal-tint) !important;
+  --secondary-foreground: var(--color-black) !important;
+  --muted: var(--color-petal-tint) !important;
+  --muted-foreground: var(--color-muted-text) !important;
+  --accent: var(--color-petal-pink-light) !important;
+  --accent-foreground: var(--color-black) !important;
+  --border: var(--color-soft-border) !important;
+
+  /* Override brand color variables used by utilities */
+  --color-brand-primary: var(--color-petal-pink) !important;
+  --color-brand-secondary: var(--color-petal-tint) !important;
+  --color-brand-accent: var(--color-petal-pink-light) !important;
+
   /* Button styling */
   --button-padding-x: 1.5rem;
   --button-padding-y: 0.75rem;
-  
-  /* Chart colors */
-  --chart-1: var(--color-sage-green) !important;
-  --chart-2: var(--color-deep-moss) !important;
-  --chart-3: var(--color-sage-light) !important;
-  --chart-4: var(--color-moss-light) !important;
-  --chart-5: var(--color-sage-dark) !important;
+
+  /* Charts (approximate mapping to pink theme) */
+  --chart-1: var(--color-petal-pink) !important;
+  --chart-2: var(--color-petal-pink-dark) !important;
+  --chart-3: var(--color-petal-pink-light) !important;
+  --chart-4: var(--color-soft-border) !important;
+  --chart-5: var(--color-muted-text) !important;
 }
 
 /* -----------------------------------------------------------------------------
@@ -53,32 +52,27 @@
  * -------------------------------------------------------------------------- */
 
 /* Background helpers ------------------------------------------------------- */
-.bg-sage-green      { background-color: var(--color-sage-green) !important; }
-.bg-deep-moss       { background-color: var(--color-deep-moss)  !important; }
-.bg-oat-beige       { background-color: var(--color-oat-beige)  !important; }
-.bg-sage-light      { background-color: var(--color-sage-light) !important; }
-.bg-sage-dark       { background-color: var(--color-sage-dark)  !important; }
+.bg-petal           { background-color: var(--color-petal-pink) !important; }
+.bg-petal-tint      { background-color: var(--color-petal-tint) !important; }
+.bg-petal-light     { background-color: var(--color-petal-pink-light) !important; }
 
 /* Text helpers ------------------------------------------------------------- */
-.text-sage-green    { color: var(--color-sage-green) !important; }
-.text-deep-moss     { color: var(--color-deep-moss)  !important; }
-.text-oat-beige     { color: var(--color-oat-beige)  !important; }
-.text-sage-light    { color: var(--color-sage-light) !important; }
-.text-sage-dark     { color: var(--color-sage-dark)  !important; }
+.text-petal         { color: var(--color-petal-pink) !important; }
+.text-muted         { color: var(--color-muted-text) !important; }
+.text-primary       { color: var(--color-black) !important; }
 
 /* Border helpers ----------------------------------------------------------- */
-.border-sage-green  { border-color: var(--color-sage-green) !important; }
-.border-deep-moss   { border-color: var(--color-deep-moss)  !important; }
-.border-oat-beige   { border-color: var(--color-oat-beige)  !important; }
+.border-petal       { border-color: var(--color-petal-pink) !important; }
+.border-soft        { border-color: var(--color-soft-border) !important; }
 
 /* Alias helpers to preserve previously-used class names -------------------- */
-.bg-brand-primary   { background-color: var(--color-sage-green) !important; }
-.text-brand-primary { color:            var(--color-sage-green) !important; }
-.border-brand-primary{ border-color:    var(--color-sage-green) !important; }
+.bg-brand-primary   { background-color: var(--color-petal-pink) !important; }
+.text-brand-primary { color:            var(--color-black) !important; }
+.border-brand-primary{ border-color:    var(--color-soft-border) !important; }
 
-.bg-brand-secondary { background-color: var(--color-deep-moss) !important; }
-.text-brand-secondary{ color:           var(--color-deep-moss) !important; }
-.border-brand-secondary{ border-color:  var(--color-deep-moss) !important; }
+.bg-brand-secondary { background-color: var(--color-petal-tint) !important; }
+.text-brand-secondary{ color:           var(--color-muted-text) !important; }
+.border-brand-secondary{ border-color:  var(--color-soft-border) !important; }
 
 /* -------------------------------------------------------------------------
  * Force common utility names (e.g. Tailwind’s *-primary classes). These rules
@@ -87,10 +81,10 @@
  * regardless of load-order or specificity issues.
  * ----------------------------------------------------------------------- */
 
-.bg-primary      { background-color: var(--color-sage-green) !important; }
-.text-primary    { color:            var(--color-sage-green) !important; }
-.border-primary  { border-color:     var(--color-sage-green) !important; }
+.bg-primary      { background-color: var(--color-petal-pink) !important; }
+.text-primary    { color:            var(--color-black) !important; }
+.border-primary  { border-color:     var(--color-soft-border) !important; }
 
-.bg-secondary    { background-color: var(--color-deep-moss) !important; }
-.text-secondary  { color:            var(--color-deep-moss) !important; }
-.border-secondary{ border-color:     var(--color-deep-moss) !important; }
+.bg-secondary    { background-color: var(--color-petal-tint) !important; }
+.text-secondary  { color:            var(--color-muted-text) !important; }
+.border-secondary{ border-color:     var(--color-soft-border) !important; }

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,9 +26,6 @@ export default defineConfig({
     },
     minify: 'esbuild',
     rollupOptions: {
-      external: [
-        '@fontsource/ibm-plex-mono/400.css',
-      ],
       onwarn(warning, warn) {
         if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
           return; // Suppress use strict warnings

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,6 +26,9 @@ export default defineConfig({
     },
     minify: 'esbuild',
     rollupOptions: {
+      external: [
+        '@fontsource/ibm-plex-mono/400.css',
+      ],
       onwarn(warning, warn) {
         if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
           return; // Suppress use strict warnings


### PR DESCRIPTION
…no fallback; BrandTitle & Kicker components; wrap app with <BrandFonts/>; hero uses BrandTitle/Kicker; Tailwind display family

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds brand typography components (BrandTitle, Kicker) and a runtime font loader that initializes fonts at app startup; hero uses the new components.

- Style
  - Whole-site typographic overhaul with new display/kicker/compact utilities, responsive title sizing, updated global/component font stacks, fallback font stylesheet, and a petal-pink brand color theme.

- Chores
  - Replaces font dependencies, exposes explicit color tokens and a BUTTON config, updates build install flags, and refreshes favicons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->