### PR TITLE
feat(public hero): add eyebrow preheader above H1; move LogoCloud sec…

### DIFF
--- a/src/components/PublicWebsite.jsx
+++ b/src/components/PublicWebsite.jsx
@@ -94,11 +94,11 @@ export default function PublicWebsite() {
       <section className="relative pt-20 pb-16 bg-[#f5f3f3]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <p className="font-body pt-2 md:pt-3 text-[0.85rem] md:text-[0.95rem] tracking-[0.14em] uppercase text-black mb-1" aria-label="Section descriptor">
+            <p className="font-body pt-3 md:pt-4 text-[0.8rem] md:text-[0.9rem] tracking-[0.14em] uppercase text-black mb-6" aria-label="Section descriptor">
               COMMUNITY & TRAINING FOR NATURAL PRODUCTS
             </p>
             <h1
-              className="font-heading text-[2.25rem] md:text-[2.6rem] font-normal md:font-medium leading-[1.15] tracking-tight text-primary mb-5 max-w-[24ch] mx-auto"
+              className="font-heading text-[2.5rem] md:text-[2.9rem] font-light md:font-normal leading-[1.15] tracking-tight text-primary mb-6 max-w-[24ch] mx-auto"
               style={{ textWrap: 'balance' }}
             >
               <span className="block">More than training.</span>

--- a/src/components/PublicWebsite.jsx
+++ b/src/components/PublicWebsite.jsx
@@ -94,6 +94,9 @@ export default function PublicWebsite() {
       <section className="relative pt-20 pb-16 bg-[#f5f3f3]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
+            <p className="text-[0.82rem] md:text-sm tracking-[0.18em] uppercase text-neutral-500/90 mb-2" aria-label="Section descriptor">
+              COMMUNITY & TRAINING FOR NATURAL PRODUCTS
+            </p>
             <h1
               className="font-heading text-3xl md:text-4xl font-medium md:font-semibold leading-[1.15] tracking-tight text-primary mb-5 max-w-[24ch] mx-auto"
               style={{ textWrap: 'balance' }}
@@ -105,10 +108,6 @@ export default function PublicWebsite() {
               Genuine connection and micro-lessons that<br />
               give you the confidence and support you need.
             </p>
-            <section aria-label="Trusted by natural product brands" className="container-lg" style={{marginTop: '2.5rem', marginBottom: '2.5rem'}}>
-              <h2 className="sr-only">Trusted by natural product brands</h2>
-              <LogoCloud logos={BRAND_LOGOS} />
-            </section>
             <div className="mt-2 flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
               <LoginWidget 
                 buttonText="Join the Community" 
@@ -122,6 +121,10 @@ export default function PublicWebsite() {
                 For Brands
               </Button>
             </div>
+            <section aria-label="Trusted by natural product brands" className="container-lg" style={{marginTop: '2.5rem', marginBottom: '2.5rem'}}>
+              <h2 className="sr-only">Trusted by natural product brands</h2>
+              <LogoCloud logos={BRAND_LOGOS} />
+            </section>
 
             <div className="grid md:grid-cols-2 gap-12 items-center mt-16">
               <div className="text-left">

--- a/src/components/PublicWebsite.jsx
+++ b/src/components/PublicWebsite.jsx
@@ -94,15 +94,15 @@ export default function PublicWebsite() {
       <section className="relative pt-20 pb-16 bg-[#f5f3f3]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <p className="text-[0.82rem] md:text-sm tracking-[0.18em] uppercase text-neutral-500/90 mb-2" aria-label="Section descriptor">
+            <p className="font-body text-[0.94rem] md:text-[1.05rem] tracking-[0.18em] uppercase text-black mb-1" aria-label="Section descriptor">
               COMMUNITY & TRAINING FOR NATURAL PRODUCTS
             </p>
             <h1
               className="font-heading text-3xl md:text-4xl font-medium md:font-semibold leading-[1.15] tracking-tight text-primary mb-5 max-w-[24ch] mx-auto"
               style={{ textWrap: 'balance' }}
             >
-              <span className="block">More than training, it's a movement.</span>
-              <span className="block">We are in this together.</span>
+              <span className="block">More than training.</span>
+              <span className="block">Together, we’re a movement.</span>
             </h1>
             <p className="text-base md:text-lg text-muted font-body max-w-3xl mx-auto mb-8">
               Genuine connection and micro-lessons that<br />

--- a/src/components/PublicWebsite.jsx
+++ b/src/components/PublicWebsite.jsx
@@ -94,11 +94,11 @@ export default function PublicWebsite() {
       <section className="relative pt-20 pb-16 bg-[#f5f3f3]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <p className="font-body text-[0.94rem] md:text-[1.05rem] tracking-[0.18em] uppercase text-black mb-1" aria-label="Section descriptor">
+            <p className="font-body text-[0.9rem] md:text-[1rem] tracking-[0.18em] uppercase text-black mb-1" aria-label="Section descriptor">
               COMMUNITY & TRAINING FOR NATURAL PRODUCTS
             </p>
             <h1
-              className="font-heading text-3xl md:text-4xl font-medium md:font-semibold leading-[1.15] tracking-tight text-primary mb-5 max-w-[24ch] mx-auto"
+              className="font-heading text-[2.25rem] md:text-[2.6rem] font-normal md:font-medium leading-[1.15] tracking-tight text-primary mb-5 max-w-[24ch] mx-auto"
               style={{ textWrap: 'balance' }}
             >
               <span className="block">More than training.</span>

--- a/src/components/PublicWebsite.jsx
+++ b/src/components/PublicWebsite.jsx
@@ -94,7 +94,7 @@ export default function PublicWebsite() {
       <section className="relative pt-20 pb-16 bg-[#f5f3f3]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <p className="font-body text-[0.9rem] md:text-[1rem] tracking-[0.18em] uppercase text-black mb-1" aria-label="Section descriptor">
+            <p className="font-body pt-2 md:pt-3 text-[0.85rem] md:text-[0.95rem] tracking-[0.14em] uppercase text-black mb-1" aria-label="Section descriptor">
               COMMUNITY & TRAINING FOR NATURAL PRODUCTS
             </p>
             <h1


### PR DESCRIPTION
…tion below CTA buttons to match layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a brief descriptor above the hero heading for clearer context and accessibility.
  * Shortened and rephrased the hero headline for tighter, more impactful messaging.
  * Relocated the trusted-by brands/logo cloud from the top of the hero to below the primary call-to-action to improve visual hierarchy.
  * Streamlined hero layout to enhance content flow and reduce distraction for visitors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->