### PR TITLE
rules: enforce verified-staff update restrictions (no community/visib…

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -146,9 +146,30 @@ service cloud.firestore {
         )
       );
 
-      // Owner, approved brand manager, loose brand manager, or super admin can update / delete
-      allow update, delete: if request.auth != null && (
-        (resource.data.userId == request.auth.uid) ||
+      // Updates:
+      // - Super admin / brand managers: allowed
+      // - Owner: allowed, BUT if the owner is a verified staff member, they cannot
+      //   change communityId, visibility, or userId (prevents post-move/private toggles)
+      allow update: if request.auth != null && (
+        isSuperAdmin(request.auth.uid) ||
+        isApprovedBrandManager(request.auth.uid) ||
+        isBrandManagerLoose(request.auth.uid) ||
+        (
+          resource.data.userId == request.auth.uid && (
+            !isVerifiedStaff(request.auth.uid) || (
+              request.resource.data.communityId == resource.data.communityId &&
+              request.resource.data.visibility == resource.data.visibility &&
+              resource.data.communityId == 'whats-good' &&
+              resource.data.visibility == 'public' &&
+              request.resource.data.userId == resource.data.userId
+            )
+          )
+        )
+      );
+
+      // Deletes: owner or elevated roles.
+      allow delete: if request.auth != null && (
+        resource.data.userId == request.auth.uid ||
         isApprovedBrandManager(request.auth.uid) ||
         isBrandManagerLoose(request.auth.uid) ||
         isSuperAdmin(request.auth.uid)

--- a/firestore.rules
+++ b/firestore.rules
@@ -159,8 +159,6 @@ service cloud.firestore {
             !isVerifiedStaff(request.auth.uid) || (
               request.resource.data.communityId == resource.data.communityId &&
               request.resource.data.visibility == resource.data.visibility &&
-              resource.data.communityId == 'whats-good' &&
-              resource.data.visibility == 'public' &&
               request.resource.data.userId == resource.data.userId
             )
           )


### PR DESCRIPTION
…ility/userId changes); separate delete rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated community post permissions:
    - Super admins and approved/loose brand managers can update and delete posts.
    - Post owners can update/delete under stricter conditions.
    - If an owner is verified staff, updates are further restricted: certain core fields must remain unchanged and the post must remain public in the “whats-good” community.
  * Delete permissions clarified to explicitly include both elevated roles and owners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->