### PR TITLE
feat(community): add Trending section in FilterBar; drive brands/tags…

### DIFF
--- a/src/components/community/FilterBar.jsx
+++ b/src/components/community/FilterBar.jsx
@@ -72,6 +72,7 @@ export default function FilterBar({
 
         {tags.length > 0 && (
           <div className="mt-2 flex flex-wrap gap-2">
+            <div className="w-full text-xs font-medium text-gray-700 mb-1">Trending</div>
             {tags.map((t) => {
               const active = selectedTags.includes(t);
               return (

--- a/src/components/community/PostCard.jsx
+++ b/src/components/community/PostCard.jsx
@@ -64,6 +64,9 @@ export default function PostCard({ post, onLike, onComment, onViewTraining, onCa
     onCardClick?.(post);
   };
 
+  const authorName = post?.authorName || post?.author?.name || '';
+  const authorPhotoURL = post?.authorPhotoURL || post?.author?.photoURL || '';
+
   return (
     <article
       className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm min-h-[140px] cursor-pointer hover:shadow-md transition-shadow focus:outline-none focus:ring-2 focus:ring-deep-moss focus:ring-offset-2"
@@ -75,13 +78,25 @@ export default function PostCard({ post, onLike, onComment, onViewTraining, onCa
       onKeyDown={handleKeyDown}
     >
       <header className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <span
             className="inline-flex items-center px-3 h-7 min-h-[28px] rounded-full text-xs font-medium border border-deep-moss/30 text-deep-moss bg-white"
             aria-label={`Brand ${brand}`}
           >
             {brand}
           </span>
+          {(authorName || authorPhotoURL) && (
+            <div className="flex items-center gap-2 text-xs text-gray-600" aria-label={`Posted by ${authorName || 'user'}`}>
+              {authorPhotoURL ? (
+                <img src={authorPhotoURL} alt="" className="w-6 h-6 rounded-full object-cover" />
+              ) : (
+                <div className="w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center text-[10px] text-gray-600">
+                  {(authorName || 'U').slice(0,1).toUpperCase()}
+                </div>
+              )}
+              <span className="truncate max-w-[140px]" title={authorName}>{authorName}</span>
+            </div>
+          )}
         </div>
         {time && (
           <time className="text-xs text-warm-gray" aria-label={`Posted ${time}`}>

--- a/src/components/community/ProFeed.jsx
+++ b/src/components/community/ProFeed.jsx
@@ -90,6 +90,7 @@ function ProFeedContent({ query = '', search = '', brand = 'All', selectedBrands
             content: data?.body || '',
             tags: Array.isArray(data?.tags) ? data.tags : [],
             authorName: data?.authorName || '',
+            authorPhotoURL: data?.authorPhotoURL || '',
             createdAt: data?.createdAt,
           };
         });

--- a/src/components/community/ProFeed.jsx
+++ b/src/components/community/ProFeed.jsx
@@ -147,7 +147,7 @@ function ProFeedContent({ query = '', search = '', brand = 'All', selectedBrands
       setLoading(false);
     }
     return () => { try { unsub(); } catch {} };
-  }, []);
+  }, [currentUser?.uid, db]);
 
   const q = (query || search).trim().toLowerCase();
   const filtered = posts.filter((p) => {

--- a/src/components/community/ProFeed.jsx
+++ b/src/components/community/ProFeed.jsx
@@ -202,6 +202,9 @@ function ProFeedContent({ query = '', search = '', brand = 'All', selectedBrands
   }
 
   const handleLike = async (post) => {
+    // Capture previous state for rollback
+    const prevLikedByMe = !!post?.likedByMe;
+    const prevLikeCount = Number.isFinite(post?.likeCount) ? post.likeCount : 0;
     try {
       // Guard first
       if (!db || !currentUser?.uid) {
@@ -231,7 +234,11 @@ function ProFeedContent({ query = '', search = '', brand = 'All', selectedBrands
       setPosts(prev => prev.map(p => (p.id === post.id ? { ...p, likeCount } : p)));
     } catch (err) {
       console.error('Failed to toggle like:', err);
-      // Optional: setError('Failed to save like. Please try again.');
+      setError('Failed to save like. Please try again.');
+      // Roll back optimistic update only for this post
+      setPosts(prev => prev.map(p => (
+        p.id === post.id ? { ...p, likedByMe: prevLikedByMe, likeCount: prevLikeCount } : p
+      )));
     }
   };
 

--- a/src/components/community/ProFeed.jsx
+++ b/src/components/community/ProFeed.jsx
@@ -162,6 +162,7 @@ export default function ProFeed({
   selectedBrands = [],
   selectedTags = [],
   onRequestVerify,
+  onFiltersChange,
 }) {
   const { isVerified, hasRole } = useAuth();
 
@@ -183,6 +184,15 @@ export default function ProFeed({
     if (devOverride === false) return false;
     return realIsVerifiedStaff;
   }, [devOverride, realIsVerifiedStaff]);
+
+  // Emit available filters from stubs when mounted/when props change
+  useEffect(() => {
+    try {
+      const brands = Array.from(new Set(PRO_STUBS.map((p) => p.brand).filter(Boolean)));
+      const tags = Array.from(new Set(PRO_STUBS.flatMap((p) => (Array.isArray(p.tags) ? p.tags : [])).filter(Boolean)));
+      onFiltersChange?.({ brands, tags });
+    } catch {}
+  }, [onFiltersChange]);
 
   return isVerifiedStaff ? (
     <ProFeedContent

--- a/src/components/community/ProFeed.jsx
+++ b/src/components/community/ProFeed.jsx
@@ -84,7 +84,7 @@ function ProFeedContent({ query = '', search = '', brand = 'All', selectedBrands
           const data = d.data();
           return {
             id: d.id,
-            brand: data?.communityName || 'Pro Feed',
+            brand: data?.brandName || 'Pro Feed',
             title: data?.title || 'Untitled',
             snippet: (data?.body || '').slice(0, 200),
             content: data?.body || '',

--- a/src/components/community/WhatsGoodFeed.jsx
+++ b/src/components/community/WhatsGoodFeed.jsx
@@ -121,7 +121,9 @@ export default function WhatsGoodFeed({
             .sort((a, b) => b[1] - a[1])
             .map(([k]) => k);
           onFiltersChange?.({ brands, tags });
-        } catch {}
+        } catch (err) {
+          console.error('WhatsGoodFeed: failed to emit filters from live posts', { baseCount: Array.isArray(base) ? base.length : 0 }, err);
+        }
 
         // Load counts per post (numeric fields) — fallback to 0 if query fails
         const enriched = await Promise.all(
@@ -170,7 +172,9 @@ export default function WhatsGoodFeed({
         const brands = Array.from(new Set(fallback.map((p) => p.brand).filter(Boolean)));
         const tags = Array.from(new Set(fallback.flatMap((p) => (Array.isArray(p.tags) ? p.tags : [])).filter(Boolean)));
         onFiltersChange?.({ brands, tags });
-      } catch {}
+      } catch (e) {
+        console.error('WhatsGoodFeed: failed to compute fallback filters', { fallbackCount: Array.isArray(fallback) ? fallback.length : 0 }, e);
+      }
       setLoading(false);
     }
     return () => {

--- a/src/components/community/WhatsGoodFeed.jsx
+++ b/src/components/community/WhatsGoodFeed.jsx
@@ -325,17 +325,15 @@ export default function WhatsGoodFeed({
       }
     } catch (err) {
       console.error('Failed to toggle like:', err);
-      // Set error state and revert optimistic update on error
       setError('Failed to save like. Please try again.');
+      // Revert optimistic update to original state (boolean + numeric count)
       setPostsWithCounts(prev => 
         prev.map(p => 
           p.id === post.id 
             ? { 
                 ...p, 
-                likeIds: post.likedByMe 
-                  ? [...(p.likeIds || []), 'me'] // revert unlike
-                  : (p.likeIds || []).filter(id => id !== 'me'), // revert like
-                likedByMe: post.likedByMe // revert state
+                likedByMe: post.likedByMe,
+                likeCount: Number.isFinite(post.likeCount) ? post.likeCount : 0,
               }
             : p
         )

--- a/src/components/community/WhatsGoodFeed.jsx
+++ b/src/components/community/WhatsGoodFeed.jsx
@@ -91,7 +91,7 @@ export default function WhatsGoodFeed({
           const data = d.data();
           return {
             id: d.id,
-            brand: data?.communityName || 'What\'s Good',
+            brand: data?.brandName || data?.communityName || 'What\'s Good',
             title: data?.title || 'Untitled',
             snippet: (data?.body || '').slice(0, 200),
             content: data?.body || '',

--- a/src/components/community/WhatsGoodFeed.jsx
+++ b/src/components/community/WhatsGoodFeed.jsx
@@ -97,6 +97,7 @@ export default function WhatsGoodFeed({
             content: data?.body || '',
             tags: Array.isArray(data?.tags) ? data.tags : [],
             authorName: data?.authorName || '',
+            authorPhotoURL: data?.authorPhotoURL || '',
             createdAt: data?.createdAt,
           };
         });

--- a/src/pages/Community.jsx
+++ b/src/pages/Community.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState, lazy, Suspense } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import FeedTabs from '../components/community/FeedTabs';
-import WhatsGoodFeed, { WHATS_GOOD_STUBS } from '../components/community/WhatsGoodFeed';
+import WhatsGoodFeed from '../components/community/WhatsGoodFeed';
 import { PRO_STUBS } from '../components/community/ProFeed';
 const ProFeed = lazy(() => import('../components/community/ProFeed'));
 import FilterBar from '../components/community/FilterBar';
@@ -18,6 +18,8 @@ export default function Community() {
   const [query, setQuery] = useState('');
   const [selectedBrands, setSelectedBrands] = useState([]);
   const [selectedTags, setSelectedTags] = useState([]);
+  const [availableBrands, setAvailableBrands] = useState([]);
+  const [availableTags, setAvailableTags] = useState([]);
 
   // Deep-link support: if navigated with { state: { focusPostId } }, redirect to detail
   useEffect(() => {
@@ -27,17 +29,15 @@ export default function Community() {
     }
   }, [location.state, navigate]);
 
-  // Canonical data source per tab
-  const posts = useMemo(() => (tab === 'whatsGood' ? WHATS_GOOD_STUBS : PRO_STUBS), [tab]);
-  // Single-source available brand/tag lists derived from posts
-  const availableBrands = useMemo(
-    () => Array.from(new Set(posts.map((p) => p.brand).filter(Boolean))),
-    [posts]
-  );
-  const availableTags = useMemo(
-    () => Array.from(new Set(posts.flatMap((p) => (Array.isArray(p.tags) ? p.tags : [])).filter(Boolean))),
-    [posts]
-  );
+  // Update available filters when tab changes (Pro uses stubs for now)
+  useEffect(() => {
+    if (tab === 'pro') {
+      const brands = Array.from(new Set(PRO_STUBS.map((p) => p.brand).filter(Boolean)));
+      const tags = Array.from(new Set(PRO_STUBS.flatMap((p) => (Array.isArray(p.tags) ? p.tags : [])).filter(Boolean)));
+      setAvailableBrands(brands);
+      setAvailableTags(tags);
+    }
+  }, [tab]);
 
   const header = useMemo(() => {
     return (
@@ -120,6 +120,10 @@ export default function Community() {
                 selectedBrands={selectedBrands}
                 selectedTags={selectedTags}
                 onStartPost={() => navigate('/staff/community/post/new')}
+                onFiltersChange={({ brands, tags }) => {
+                  setAvailableBrands(Array.from(new Set((brands || []).filter(Boolean))));
+                  setAvailableTags(Array.from(new Set((tags || []).filter(Boolean))));
+                }}
               />
             ) : (
               <Suspense
@@ -137,6 +141,10 @@ export default function Community() {
                   selectedTags={selectedTags}
                   onRequestVerify={() => {
                     navigate('/staff/verification');
+                  }}
+                  onFiltersChange={({ brands, tags }) => {
+                    setAvailableBrands(Array.from(new Set((brands || []).filter(Boolean))));
+                    setAvailableTags(Array.from(new Set((tags || []).filter(Boolean))));
                   }}
                 />
               </Suspense>

--- a/src/pages/Community.jsx
+++ b/src/pages/Community.jsx
@@ -1,5 +1,5 @@
 // src/pages/Community.jsx
-import { useEffect, useMemo, useState, lazy, Suspense } from 'react';
+import { useEffect, useMemo, useState, useCallback, lazy, Suspense } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import FeedTabs from '../components/community/FeedTabs';
 import WhatsGoodFeed from '../components/community/WhatsGoodFeed';
@@ -20,6 +20,12 @@ export default function Community() {
   const [selectedTags, setSelectedTags] = useState([]);
   const [availableBrands, setAvailableBrands] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
+
+  // Stable handler to receive filters (brands/tags) from child feeds
+  const handleFiltersChange = useCallback(({ brands, tags } = {}) => {
+    setAvailableBrands(Array.from(new Set((brands || []).filter(Boolean))));
+    setAvailableTags(Array.from(new Set((tags || []).filter(Boolean))));
+  }, []);
 
   // Deep-link support: if navigated with { state: { focusPostId } }, redirect to detail
   useEffect(() => {
@@ -120,10 +126,7 @@ export default function Community() {
                 selectedBrands={selectedBrands}
                 selectedTags={selectedTags}
                 onStartPost={() => navigate('/staff/community/post/new')}
-                onFiltersChange={({ brands, tags }) => {
-                  setAvailableBrands(Array.from(new Set((brands || []).filter(Boolean))));
-                  setAvailableTags(Array.from(new Set((tags || []).filter(Boolean))));
-                }}
+                onFiltersChange={handleFiltersChange}
               />
             ) : (
               <Suspense
@@ -142,10 +145,7 @@ export default function Community() {
                   onRequestVerify={() => {
                     navigate('/staff/verification');
                   }}
-                  onFiltersChange={({ brands, tags }) => {
-                    setAvailableBrands(Array.from(new Set((brands || []).filter(Boolean))));
-                    setAvailableTags(Array.from(new Set((tags || []).filter(Boolean))));
-                  }}
+                  onFiltersChange={handleFiltersChange}
                 />
               </Suspense>
             )}

--- a/src/pages/PostCompose.jsx
+++ b/src/pages/PostCompose.jsx
@@ -160,6 +160,7 @@ export default function PostCompose() {
         createdAt: serverTimestamp(),
         userId: user?.uid || null,
         authorName: user?.displayName || user?.email || 'Staff',
+        authorPhotoURL: user?.photoURL || null,
         authorRole: user?.role || 'staff',
         ...(brandId ? { brandId } : {}),
         ...(brandName ? { brandName } : {}),

--- a/src/pages/PostCompose.jsx
+++ b/src/pages/PostCompose.jsx
@@ -18,7 +18,7 @@ import { useAuth } from '../contexts/auth-context';
 export default function PostCompose() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user } = useAuth();
+  const { user, hasRole } = useAuth();
 
   const headingRef = useRef(null);
   const [title, setTitle] = useState('');
@@ -45,7 +45,7 @@ export default function PostCompose() {
         let items = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 
         // If verified staff, include Pro Feed even if not public
-        const isVerifiedStaff = ['verified_staff', 'brand_manager', 'super_admin'].includes(user?.role);
+        const isVerifiedStaff = hasRole && hasRole(['verified_staff', 'staff', 'brand_manager', 'super_admin']);
         if (isVerifiedStaff) {
           try {
             const proRef = doc(db, 'communities', 'pro-feed');
@@ -77,7 +77,7 @@ export default function PostCompose() {
       }
     };
     loadCommunities();
-  }, [location.search, user?.role]);
+  }, [location.search, user?.role, hasRole]);
 
   const canSubmit = title.trim().length > 0 && body.trim().length > 0 && !submitting;
 

--- a/src/pages/PostCompose.jsx
+++ b/src/pages/PostCompose.jsx
@@ -53,15 +53,29 @@ export default function PostCompose() {
         // If verified staff, include Pro Feed even if not public
         const isVerifiedStaff = hasRole && hasRole(['verified_staff', 'staff', 'brand_manager', 'super_admin']);
         if (isVerifiedStaff) {
+          let ensured = false;
           try {
             const proRef = doc(db, 'communities', 'pro-feed');
             const proDoc = await getDoc(proRef);
+            const exists = items.some((c) => c.id === 'pro-feed');
             if (proDoc.exists()) {
               const data = { id: 'pro-feed', ...proDoc.data() };
-              const exists = items.some((c) => c.id === 'pro-feed');
               if (!exists) items.push(data);
+              ensured = true;
+            } else if (!exists) {
+              items.push({ id: 'pro-feed', name: 'Pro Feed', isActive: true, isPublic: false });
+              ensured = true;
             }
-          } catch {}
+          } catch {
+            const exists = items.some((c) => c.id === 'pro-feed');
+            if (!exists) {
+              items.push({ id: 'pro-feed', name: 'Pro Feed', isActive: true, isPublic: false });
+              ensured = true;
+            }
+          }
+          if (ensured) {
+            // no-op; kept for readability
+          }
         }
         if (!items || items.length === 0) {
           items = [{ id: 'whats-good', name: "What's Good" }];

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -104,6 +104,8 @@ export default function PostDetail() {
               snippet: data.body || '',
               content: data.body || '',
               createdAt: data.createdAt || null,
+              authorName: data.authorName || '',
+              authorPhotoURL: data.authorPhotoURL || '',
               trainingId: data.trainingId || null,
               likeIds: [],
               commentIds: [],
@@ -310,6 +312,8 @@ export default function PostDetail() {
         brandId: post.brandId || null,
         userId: user.uid,
         userRole: user.role || 'user',
+        authorName: user.displayName || user.email || 'User',
+        authorPhotoURL: user.photoURL || null,
         text,
         createdAt: serverTimestamp(),
       });
@@ -340,6 +344,8 @@ export default function PostDetail() {
         brandId: post.brandId || null,
         userId: user.uid,
         userRole: user.role || 'user',
+        authorName: user.displayName || user.email || 'User',
+        authorPhotoURL: user.photoURL || null,
         text: cmt.text,
         createdAt: serverTimestamp(),
       });
@@ -398,10 +404,22 @@ export default function PostDetail() {
             </div>
           )}
           <header className="flex items-start justify-between gap-3">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-3">
               <span className="inline-flex items-center px-3 h-7 min-h-[28px] rounded-full text-xs font-medium border border-deep-moss/30 text-deep-moss bg-white">
                 {post.brand || 'General'}
               </span>
+              {(post.authorName || post.authorPhotoURL) && (
+                <div className="flex items-center gap-2 text-xs text-gray-600">
+                  {post.authorPhotoURL ? (
+                    <img src={post.authorPhotoURL} alt="" className="w-6 h-6 rounded-full object-cover" />
+                  ) : (
+                    <div className="w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center text-[10px] text-gray-600">
+                      {(post.authorName || 'U').slice(0,1).toUpperCase()}
+                    </div>
+                  )}
+                  <span className="truncate max-w-[160px]" title={post.authorName}>{post.authorName}</span>
+                </div>
+              )}
             </div>
             {timeText && (
               <time className="text-xs text-warm-gray">{timeText}</time>
@@ -477,7 +495,18 @@ export default function PostDetail() {
               {comments.map((c) => (
                 <li key={c.id} className="bg-white rounded-lg border border-gray-200 p-3">
                   <div className="flex items-center justify-between text-xs text-gray-500">
-                    <span>{c.userRole || 'user'}</span>
+                    <div className="flex items-center gap-2">
+                      {c.authorPhotoURL ? (
+                        <img src={c.authorPhotoURL} alt="" className="w-6 h-6 rounded-full object-cover" />
+                      ) : (
+                        <div className="w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center text-[10px] text-gray-600">
+                          {(c.authorName || 'U').slice(0,1).toUpperCase()}
+                        </div>
+                      )}
+                      <span className="text-gray-700">{c.authorName || 'User'}</span>
+                      <span className="text-gray-400">•</span>
+                      <span>{c.userRole || 'user'}</span>
+                    </div>
                     <span>
                       {typeof c.createdAt?.toDate === 'function'
                         ? c.createdAt.toDate().toLocaleString()


### PR DESCRIPTION
… from live feeds (WhatsGood emits trending via onFiltersChange; Pro emits from stubs); allow verified staff to post to Pro Feed by including private community in compose dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Trending” label above tag chips.
  * Feeds (Pro & What’s Good) emit available brands/tags to sync page filters and accept an external filter callback.
  * Real-time feeds with optimistic like toggles, live counts, and enriched author info.
  * Posts/comments now show author name/avatar; post and comment delete actions added.
  * Compose extracts hashtags and includes author/brand metadata; verified staff see Pro Feed.

* **Bug Fixes**
  * Data load failures fall back to stub content and surface an error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->